### PR TITLE
Unnecessary import of ReactWebViewManager

### DIFF
--- a/android/src/main/java/com/philipphecht/RNDocViewerModule.java
+++ b/android/src/main/java/com/philipphecht/RNDocViewerModule.java
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.views.webview.ReactWebViewManager;
 
 /* bridge react native
 int size();


### PR DESCRIPTION
Makes it hard to compile the android app with RN > 0.60 as jetify doesn't remove unnecessary import and `ReactWebViewManager` is no more available inside the core react package instead it has been moved to react-native-community.